### PR TITLE
chore(help): add example

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -21,7 +21,7 @@ func Run(argv []string, data []byte, outStream, errStream io.Writer) error {
 	fs := flag.NewFlagSet(nameAndVer, flag.ContinueOnError)
 	fs.SetOutput(errStream)
 	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), "Usage of %s:\n", nameAndVer)
+		fmt.Fprintf(fs.Output(), "Usage of %s:\n%s [OPTION]... [--] FILE\n", nameAndVer, cmdName)
 		fs.PrintDefaults()
 	}
 


### PR DESCRIPTION
```
$ go run cmd/import-list/main.go -help
Usage of import-list (v0.1.0 rev:HEAD):
import-list [OPTION]... [--] FILE
  -version
        display version
  -z    use NULs as output field terminators
```